### PR TITLE
Care Instructions improvements

### DIFF
--- a/src/app/care-instructions/_components/CareInstructionButton.tsx
+++ b/src/app/care-instructions/_components/CareInstructionButton.tsx
@@ -14,7 +14,7 @@ export default function CareInstructionButton(props: {
 }) {
   const { id } = props.instruction;
   const title = truncateText(props.instruction.title, 100);
-  const content = truncateText(props.instruction.content, 250);
+  const content = truncateText(props.instruction.content.split("\n")[0], 250);
 
   return (
     <Link

--- a/src/app/care-instructions/_components/CareInstructionButton.tsx
+++ b/src/app/care-instructions/_components/CareInstructionButton.tsx
@@ -7,21 +7,26 @@
 import { CareInstruction } from "@/types/care-instructions";
 import styles from "./CareInstructionButton.module.css";
 import Link from "next/link";
+import truncateText from "@/utils/truncate";
 
 export default function CareInstructionButton(props: {
   instruction: CareInstruction;
 }) {
+  const { id } = props.instruction;
+  const title = truncateText(props.instruction.title, 100);
+  const content = truncateText(props.instruction.content, 250);
+
   return (
     <Link
       style={{ color: "black", textDecoration: "none" }}
       href={{
         pathname: "./care-instructions/view/",
-        query: { id: props.instruction.id },
+        query: { id },
       }}
     >
       <div className={styles.singleCareInstruction}>
-        <h3>{props.instruction.title}</h3>
-        <p>{props.instruction.content}</p>
+        <h3>{title}</h3>
+        <p>{content}</p>
 
         <p className={styles.tapMessage}>Tap for more...</p>
       </div>

--- a/src/app/care-instructions/view/page.tsx
+++ b/src/app/care-instructions/view/page.tsx
@@ -47,12 +47,6 @@ function EditInstructions() {
     }
   });
 
-  useKeyPress("Enter", () => {
-    if (onEditMode && title.trim() !== "" && content.trim() !== "") {
-      handleOnSaveClick();
-    }
-  });
-
   function fetchInformation(fetch_id: string) {
     invoke<CareInstruction>("get_single_care_instruction", {
       id: fetch_id,

--- a/src/app/care-instructions/view/page.tsx
+++ b/src/app/care-instructions/view/page.tsx
@@ -5,7 +5,6 @@
  * License:  GNU General Public License v3.0
  */
 "use client";
-import BackButton from "@/components/BackButton";
 import { useRouter, useSearchParams } from "next/navigation";
 import styles from "./page.module.css";
 import Button from "@/components/Button";
@@ -174,8 +173,8 @@ function EditInstructions() {
                 </div>
               ) : null}
               <h2>{title}</h2>
-              {content.split("\n").map((line) => {
-                return <p key={line}>{line}</p>;
+              {content.split("\n").map((line, index) => {
+                return <p key={index}>{line}</p>;
               })}
             </>
           )}

--- a/src/utils/truncate.ts
+++ b/src/utils/truncate.ts
@@ -1,0 +1,9 @@
+/**
+ * File:     utils/truncate.ts
+ * Purpose:  Truncating and other related functions.
+ * Authors:  Ojos Project & Iris contributors
+ * License:  GNU General Public License v3.0
+ */
+export default function truncateText(text: string, limit: number) {
+  return text.length > limit ? text.slice(0, limit).trim() + "..." : text;
+}


### PR DESCRIPTION
- Truncate long instructions in the main page
- Only display first paragraph in the main page
- Remove `Enter` keyboard shortcut in a CI page to allow paragraphs
